### PR TITLE
Updated README to make apploader work on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,15 @@ Now you can remote update your app:
   cordova platform add ios@3.7.0
   cordova plugin add org.apache.cordova.file
   cordova plugin add org.apache.cordova.file-transfer
+  cordova plugin add cordova-plugin-whitelist
 ```
 
 **IMPORTANT:** For iOS, use Cordova 3.7.0 or higher (due to a [bug](https://github.com/AppGyver/steroids/issues/534) that affects requestFileSystem).
+
+For Android, the plugin `cordova-plugin-whitelist` is needed. You must also add the following to your `config.xml` file.
+
+    <access origin="cdvfile://*" />
+    <allow-intent href="cdvfile://*" />
 
 ### Download and include bootstrap.js
 


### PR DESCRIPTION
To make the apploader work on Android devices you need the allow the `cdvfile` protocol.
The whitelist plugin is needed for this and changes to config.xml to allow the protocol.

This PR is a simple addition to the instructions to make it easier for users to get this to work.

Thanks for a great repo!
