### PR TITLE
Add example gulp plugin gist to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ node node_modules/cordova-app-loader/bin/update-manifest [root-directory] [manif
 
 It will update the version of only changed files (with a hash of the content).
 
-There is also [a Gruntfile](https://gist.github.com/arieljake/19447838b29a3e2da92b) available.
+There is also [a Gruntfile](https://gist.github.com/arieljake/19447838b29a3e2da92b) or [a gulp plugin](https://gist.github.com/SystemParadox/21504931bffee2f5aa023f5011ee35ce) available.
 
 ## Usage / API
 


### PR DESCRIPTION
I've created a simple gulp plugin to generate the manifest.json and added it to a gist.

If it would be useful I can publish it on npm, although I would like to use a shorter name than `gulp-cordava-app-loader-manifest`! Any suggestions?